### PR TITLE
Sample factory integration

### DIFF
--- a/examples/procgen_prims.py
+++ b/examples/procgen_prims.py
@@ -26,14 +26,13 @@ def create_env(executable=None, port=None, headless=None):
     maze_depth = 3
     n_objects = 1
 
-    for i in range(2):
-        for j in range(2):
+    for i in range(8):
+        for j in range(8):
             maze = ProcGenPrimsMaze3D(maze_width, maze_depth, wall_material=yellow_material)
             maze += sm.Box(
                 position=[0, 0, 0], bounds=[0.0, maze_width, 0, 0.1, 0.0, maze_depth], material=blue_material
             )
             agent_position = [math.floor(maze_width / 2.0) + 0.5, 0.0, math.floor(maze_depth / 2.0) + 0.5]
-            print(agent_position)
             agent = sm.SimpleRlAgent(camera_width=36, camera_height=36, position=agent_position)
             maze += agent
 
@@ -73,7 +72,7 @@ def create_env(executable=None, port=None, headless=None):
             agent.add_reward_function(timeout_reward_function)
             scene.engine.add_to_pool(maze)
 
-    scene.show(n_maps=3)
+    scene.show(n_maps=32)
     return scene
 
 

--- a/examples/sample_factory_training.py
+++ b/examples/sample_factory_training.py
@@ -1,0 +1,37 @@
+
+import sys
+
+from sample_factory.algorithms.utils.arguments import arg_parser, parse_args
+from sample_factory.envs.env_registry import global_env_registry
+from sample_factory.run_algorithm import run_algorithm
+
+from procgen_prims import create_env
+
+#import torch
+#torch.multiprocessing.set_start_method('spawn')
+
+def make_env_func(full_env_name, cfg=None, env_config=None):
+    port = 56000
+    if env_config:
+        port += 1 + env_config.env_id
+
+    return create_env(executable="/home/edward/work/simenv/integrations/Unity/builds/simenv_unity.x86_64", port=port, headless=True)
+
+
+def register_custom_components():
+    global_env_registry().register_env(
+        env_name_prefix='simenv',
+        make_env_func=make_env_func,
+    )
+
+def main():
+    """Script entry point."""
+    register_custom_components()
+    parser = arg_parser()
+    cfg = parse_args(parser=parser)
+    status = run_algorithm(cfg)
+    return status
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/Agent.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/Agent.cs
@@ -36,11 +36,11 @@ namespace SimEnv.RlAgents {
 
             // We connect the observation devices to the agent now that the whole scene is imported
             foreach (string obsDeviceName in obsDeviceNames) {
-                Debug.Log("Finding obs device" + obsDeviceName);
+                //Debug.Log("Finding obs device" + obsDeviceName);
                 Node cameraNode = GameObject.Find(obsDeviceName).GetComponent<Node>();
 
                 if (cameraNode != null) {
-                    Debug.Log("Adding observation device " + obsDeviceName + cameraNode.renderCamera);
+                    //Debug.Log("Adding observation device " + obsDeviceName + cameraNode.renderCamera);
                     obsDevices.Add(cameraNode.renderCamera);
                 } else {
                     Debug.LogError("Could not find observation device " + obsDeviceName);

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/Commands/Step.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/Commands/Step.cs
@@ -18,7 +18,7 @@ namespace SimEnv.RlAgents {
             foreach (var item in action.ToList()) {
                 List<float> convertedAction = new List<float>();
                 convertedAction.Add(item);
-                convertedActions.Add(covertedAction);
+                convertedActions.Add(convertedAction);
             }
 
             EnvironmentManager.instance.Step(convertedActions);

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/EnvironmentManager.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLAgents/EnvironmentManager.cs
@@ -21,7 +21,7 @@ namespace SimEnv.RlAgents {
         uint[] agentPixelValues;
         int obsSize;
 
-        public void Initialize(){
+        public void Initialize() {
             frameSkip = Client.instance.frameSkip;
             physicsUpdateRate = Client.instance.physicsUpdateRate;
         }
@@ -96,7 +96,6 @@ namespace SimEnv.RlAgents {
         }
 
         public void ResetAgents() {
-            Debug.Log("resetting agents");
             for (int i = 0; i < activeEnvironments.Count; i++) {
                 ResetAt(i);
             }

--- a/src/simenv/engine/unity_engine.py
+++ b/src/simenv/engine/unity_engine.py
@@ -33,7 +33,7 @@ class UnityEngine(Engine):
         engine_headless=None,
         engine_port=55000,
         physics_update_rate=30.0,
-        frame_skip=15,
+        frame_skip=4,
     ):
         super().__init__(scene=scene, auto_update=auto_update)
         self.start_frame = start_frame

--- a/src/simenv/scene.py
+++ b/src/simenv/scene.py
@@ -135,6 +135,15 @@ class Scene(Asset, Env):
     def agents(self) -> Tuple[Asset]:
         return self.tree_filtered_descendants(lambda node: isinstance(node.rl_component, RlComponent))
 
+
+    @property
+    def num_agents(self) -> int:
+        return self.n_agents
+
+    @property
+    def is_multiagent(self) -> bool:
+        return self.n_agents > 1
+
     @property
     def n_agents(self) -> int:
         if self._n_agents is None:


### PR DESCRIPTION
Adds sample factory integration, example in examples/sample_factory_training.py

Note, there is a bug with torch.multiprocessing in pytorch 1.12 using 1.11 (pip install torch==1.11.0)

Command to run the training:
python examples/sample_factory_training.py --env=simenv --experiment=simenv --num_workers=30 --num_envs_per_worker=1 --algo=APPO --worker_num_splits=1 --ppo_epochs=1