### PR TITLE
Fixing some breaking bugs on main

### DIFF
--- a/examples/mountaincar.py
+++ b/examples/mountaincar.py
@@ -18,6 +18,7 @@ def create_scene(build_exe=None, gltf_path=None):
 
 def add_rl_components_to_scene(scene):
     actor = scene.MountainCar_Cart
+    actor.is_actor = True
 
     # Add action mappings, moving left and right
     mapping = [
@@ -54,6 +55,7 @@ if __name__ == "__main__":
     env = sm.RLEnv(scene)
 
     for i in range(10000):
-        obs, reward, done, info = env.step()
+        action = [env.action_space.sample()]
+        obs, reward, done, info = env.step(action=action)
 
     input("Press enter to continue...")

--- a/examples/playground.py
+++ b/examples/playground.py
@@ -48,7 +48,7 @@ def make_scene(build_exe, camera_width, camera_height):
             with_collider=True,
         )
 
-    scene += sm.Camera(sensor_name="SecurityCamera", position=[0, 32, 0], rotation=[90, 0, 0])
+    scene += sm.Camera(name="SecurityCamera", position=[0, 32, 0], rotation=[90, 0, 0])
 
     # Lets add an actor in the scene, a capsule mesh with associated actions and a camera as observation device
     actor = sm.EgocentricCameraActor(name="actor", position=[0.0, 0.5, 0.0])  # Has a collider
@@ -97,7 +97,8 @@ if __name__ == "__main__":
     axim2 = ax2.imshow(dummy_obs2, vmin=0, vmax=255)
 
     for i in range(100):
-        obs, reward, done, info = env.step()
+        action = [env.action_space.sample()]
+        obs, reward, done, info = env.step(action=action)
         axim1.set_data(obs["CameraSensor"].reshape(3, camera_height, camera_width).transpose(1, 2, 0))
         fig1.canvas.flush_events()
         axim2.set_data(obs["SecurityCamera"].reshape(3, 256, 256).transpose(1, 2, 0))

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Bridge/Client.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Bridge/Client.cs
@@ -37,7 +37,6 @@ namespace SimEnv {
         /// Connect to server and begin listening for commands.
         /// </summary>
         public static void Initialize(string host = "localhost", int port = 55000) {
-            Debug.Log("Initializing Tcp Client");
             Client.host = host;
             Client.port = port;
             LoadCommands();

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Bridge/Initialize.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Bridge/Initialize.cs
@@ -15,7 +15,7 @@ namespace SimEnv {
                 await Simulator.Initialize(b64bytes, kwargs);
             } catch (System.Exception e) {
                 string error = "Failed to build scene from GLTF: " + e.ToString();
-                Debug.LogWarning(error);
+                Debug.LogError(error);
                 callback(error);
                 return;
             }

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/GLTFNode.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/GLTFNode.cs
@@ -256,7 +256,6 @@ namespace SimEnv.GLTF {
                             if (extensions == null || extensions.HF_reward_functions == null || extensions.HF_reward_functions.objects == null || extensions.HF_reward_functions.objects.Count < rewardValue) {
                                 Debug.LogWarning("Error importing reward function");
                             } else {
-                                Debug.Log(extensions.HF_reward_functions.objects[rewardValue].type);
                                 result[i].node.rewardFunctionData = extensions.HF_reward_functions.objects[rewardValue];
                             }
                         }

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/HF_actuators.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/HF_actuators.cs
@@ -30,7 +30,6 @@ namespace SimEnv.GLTF {
             public string? dtype;
 
             public int? seed;
-
         }
 
         public class ActionMapping {
@@ -57,7 +56,6 @@ namespace SimEnv.GLTF {
 
             [JsonProperty("max_velocity_threshold")]
             public float? maxVelocityThreshold;
-
         }
 
         public class Actuator {
@@ -81,8 +79,6 @@ namespace SimEnv.GLTF {
                 }
             }
         }
-
-
     }
 }
 

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLActors/RLPlugin.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLActors/RLPlugin.cs
@@ -79,6 +79,7 @@ namespace SimEnv.RlAgents {
                     bufferShape.ToArray(),
                     sensor.GetSensorBufferType()
                 );
+                // TODO: error is thrown due to multiple sensors with the same name here
                 sensorBuffers.Add(sensor.GetName(), sensorBuffer);
             }
             int[] shape = { nActiveMaps, nActors, 1 };

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLActors/Sensors/RaycastSensor.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/RLActors/Sensors/RaycastSensor.cs
@@ -21,7 +21,6 @@ namespace SimEnv {
             m_node = node;
             mName = data.sensor_tag;
             // calculate ray angles etc
-            Debug.Log("instantiating raycast sensor");
 
             nHorizontalRays = data.n_horizontal_rays;
             nVerticalRays = data.n_vertical_rays;

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Simulator.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/Simulator.cs
@@ -40,11 +40,9 @@ namespace SimEnv {
         public static EventData currentEvent { get; private set; }
 
         private void Awake() {
-            Debug.Log("Waking up simulator");
             Physics.autoSimulation = false;
             LoadCustomAssemblies();
             LoadPlugins();
-            // TODO: Option to parse simulation args directly from API
             GetCommandLineArgs(out int port);
             Client.Initialize("localhost", port);
         }
@@ -102,8 +100,6 @@ namespace SimEnv {
             kwargs.TryParse("time_step", out Config.instance.timeStep, timeStep);
             kwargs.TryParse("return_nodes", out Config.instance.returnNodes, returnNodes);
             kwargs.TryParse("return_frames", out Config.instance.returnFrames, returnFrames);
-
-            Debug.Log($"Stepping {Config.instance.frameSkip} frames with {Config.instance.timeStep} time step");
 
             if (currentEvent == null)
                 currentEvent = new EventData();

--- a/src/simenv/rl/rl_env.py
+++ b/src/simenv/rl/rl_env.py
@@ -105,7 +105,7 @@ class RLEnv(VecEnv):
             n_show=n_show,
         )
 
-    def step(self, action=None):
+    def step(self, action):
         """The step function for the environment.
 
         Action is a dict with actuator tags as keys and as values a Tensor of shape (n_show, n_actors, n_actions)
@@ -114,7 +114,7 @@ class RLEnv(VecEnv):
         self.step_send_async(action=action)
         return self.step_recv_async()
 
-    def step_send_async(self, action=None):
+    def step_send_async(self, action):
         if not isinstance(action, dict):
             if len(self.action_tags) != 1:
                 raise ValueError(

--- a/src/simenv/scene.py
+++ b/src/simenv/scene.py
@@ -140,10 +140,6 @@ class Scene(Asset):
         """
         if not self._is_shown:
             raise ValueError("The scene should be shown before stepping it (call scene.show()).")
-        if len(self.actors) == 0:
-            raise ValueError(
-                "The scene should have at least one actor to step. Set is_actor=True on the root node of your actor."
-            )
         if time_step is not None:
             engine_kwargs.update({"time_step": time_step})
         if frame_skip is not None:


### PR DESCRIPTION
- `RLEnv.step()` now requires an action to be passed. I've updated the `mountaincar` and `playground` examples to reflect this, and removed the default action=None arg from `RLEnv`
- Removed the error that was raised when there are no actors, which broke non-RL examples
- Changed warning on `Initialize` failure to an error to make it more clear when initialization fails
- Passed `is_actor=True` explicitly in mountaincar example, which we may want to change
- TODO: Still breaking sensor name bugs